### PR TITLE
README: remove link to unofficial iperf website

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Install the following on both the WG server and WG peer
     ```
 * Install `iperf3`
     ```bash
-    # Source: https://iperf.fr/iperf-download.php
+    # Ubuntu
+    sudo apt install iperf3
     ```
 * Install `sed`
     ```bash


### PR DESCRIPTION
Hi,
Here's a small fix for an issue I noticed while checking the README.
Ubuntu packages iperf3, there's no need to get the outdated binaries offered by iperf.fr.
See also https://github.com/esnet/iperf/issues/1459#issuecomment-1402776239